### PR TITLE
don't log when rosout might be uninitialized

### DIFF
--- a/rosrust/src/tcpros/util/tcpconnection.rs
+++ b/rosrust/src/tcpros/util/tcpconnection.rs
@@ -26,11 +26,11 @@ where
         match stream {
             Ok(stream) => {
                 let _ = stream.set_write_timeout(Some(std::time::Duration::from_millis(100)));
-                let debug_msg = format!(
-                    "new connection: t = {} | tag = {} | peer: {:?} | read timeout: {:?} | write timeout: {:?}",
-                    crate::now(), &tag, stream.peer_addr(), stream.read_timeout(), stream.write_timeout()
-                ).replace('\n', "");
-                log::info!("{}", debug_msg);
+                // let debug_msg = format!(
+                //     "new connection: t = {} | tag = {} | peer: {:?} | read timeout: {:?} | write timeout: {:?}",
+                //     crate::now(), &tag, stream.peer_addr(), stream.read_timeout(), stream.write_timeout()
+                // ).replace('\n', "");
+                // dbg!("{}", debug_msg);
                 match handler(stream) {
                     Feedback::AcceptNextStream => {}
                     Feedback::StopAccepting => break,


### PR DESCRIPTION
fixes a regression of
- https://github.com/farming-revolution/rosrust/pull/4

encountered in our pcu23 node