### PR TITLE
fix subscribing /nested/param/structures

### DIFF
--- a/rosrust/src/api/ros.rs
+++ b/rosrust/src/api/ros.rs
@@ -531,7 +531,11 @@ impl Parameter {
 
     pub fn get<'b, T: Deserialize<'b>>(&self) -> Response<T> {
         let data = self.get_raw()?;
-        Deserialize::deserialize(data).map_err(bad_response_structure)
+        let res = Deserialize::deserialize(data);
+        if let Err(ref e) = res {
+            eprintln!("{:?}", e);
+        }
+        res.map_err(bad_response_structure)
     }
 
     pub fn get_raw(&self) -> Response<xml_rpc::Value> {

--- a/rosrust/src/api/slave/handler.rs
+++ b/rosrust/src/api/slave/handler.rs
@@ -3,7 +3,7 @@ use super::subscriptions::SubscriptionsTracker;
 use crate::rosxmlrpc::{self, Response, ResponseError, Server};
 use crate::tcpros::Service;
 use crate::util::{kill, FAILED_TO_LOCK};
-use log::{error, info};
+use log::{error, info, debug};
 use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::sync::{Arc, Mutex};
@@ -178,7 +178,7 @@ impl SlaveHandler {
 
             for (subscribed_param_name, cb) in callbacks.iter() {
                 if one_is_prefix_of_other(key, subscribed_param_name.as_str()) {
-                    info!("param '{key}' changed, notifying subscriber of '{subscribed_param_name}' at address: {:p}", &*cb);
+                    debug!("param '{key}' changed, notifying subscriber of '{subscribed_param_name}' at address: {:p}", &*cb);
                     cb();
                 }
             }

--- a/rosrust/src/api/slave/handler.rs
+++ b/rosrust/src/api/slave/handler.rs
@@ -160,10 +160,25 @@ impl SlaveHandler {
                 .data
                 .retain(|k, _| !k.starts_with(key) && !key.starts_with(k));
 
-            let callbacks = param_callbacks.lock().unwrap();            
+            let callbacks = param_callbacks.lock().unwrap();
+
+            /// helper to get the //elements/of//the/param/name/ → [elements, of, the, param, name]
+            fn get_path_elements(s : &str) -> impl Iterator<Item = &str> {
+                s.split('/').filter(|e| *e != "/" && e.len() > 0)
+            }
+
+            /// prefix checking, so that we can notify
+            /// - a subscriber of /foo/bar if /foo changes
+            /// - a subscriber of /foo if /foo/bar changes
+            fn one_is_prefix_of_other(a : &str, b : &str) -> bool {
+                let a = get_path_elements(a);
+                let b = get_path_elements(b);
+                a.zip(b).all(|(ai, bi)| ai==bi)
+            }
+
             for (subscribed_param_name, cb) in callbacks.iter() {
-                if subscribed_param_name.as_str() == key {
-                    //println!("prefix: '{subscribed_param_name}'\npointer: {:p}", &*cb);
+                if one_is_prefix_of_other(key, subscribed_param_name.as_str()) {
+                    info!("param '{key}' changed, notifying subscriber of '{subscribed_param_name}' at address: {:p}", &*cb);
                     cb();
                 }
             }


### PR DESCRIPTION
this fix enables us to use DynamicParam with types such as

```rust
#[derive(Serialize, Deserialize, Debug, Clone)]
struct MechanicalTreatmentParams {
    #[serde(rename = "oval_safety_distance_before_m")]
    safety_x_before_m: f64,
    #[serde(rename = "oval_safety_distance_after_m")]
    safety_x_after_m: f64,
    #[serde(rename = "safety_distance_y_m")]
    safety_y: f64,
    polygon_threshold: usize,
    small_beets_mode: SmallBeetsModeParam,
}
```

```rust
    let mechanical_params = DynamicParam::new(
        "/stem_based_treatment_planner",
        MechanicalTreatmentParams::default(),
    );
```