### PR TITLE
fixes to message generation

### DIFF
--- a/rosrust_codegen/src/msg.rs
+++ b/rosrust_codegen/src/msg.rs
@@ -75,15 +75,24 @@ impl Msg {
         
         let call = Ident::new("include_str", Span::call_site());
         let excl = Punct::new('!', Spacing::Alone);
-        let inside = Literal::string(self.0.get_file_path().canonicalize().unwrap().to_str().unwrap());
         
-        let fn_definition = if self.0.get_file_path().exists() {
+        fn check_path(msg: &Msg) -> std::option::Option<String> {
+            let p = msg.0.get_file_path();
+            if !p.exists() {
+                return None
+            }
+            Some(p.canonicalize().ok()?.to_str()?.to_owned())
+        }
+        
+        let fn_definition = if let Some(s) = check_path(self) {
+            let inside = Literal::string(s.as_str());
             quote!{
                 #call #excl (#inside)
             }
         } else {
+            let s = self.0.source();
             quote!{
-                self.get_definition()
+                #s
             }
         };
         

--- a/rosrust_codegen/src/output_layout.rs
+++ b/rosrust_codegen/src/output_layout.rs
@@ -145,7 +145,7 @@ impl Service {
             impl #crate_prefix Message for #name_ident {
                 #[inline]
                 fn msg_definition() -> ::std::string::String {
-                    String::new()
+                    ::std::string::String::new()
                 }
 
                 #[inline]


### PR DESCRIPTION
- fix handling of messages with no available source file (would generate call to non-existent method)
- fix bug when the message type is called `String` (the new type would shadow `std::string::String` and then a call to `String::new` could not be compiled because that new type does not have a `new` method)